### PR TITLE
Add optional sessionToken to credentials object

### DIFF
--- a/main.js
+++ b/main.js
@@ -23,6 +23,11 @@ function signedFetch(url, opts, creds) {
 	creds.accessKeyId  = creds.accessKeyId || process.env.ES_AWS_ACCESS_KEY || process.env.AWS_ACCESS_KEY || process.env.AWS_ACCESS_KEY_ID;
 	creds.secretAccessKey  = creds.secretAccessKey || process.env.ES_AWS_SECRET_ACCESS_KEY || process.env.AWS_SECRET_ACCESS_KEY;
 
+	const sessionToken = creds.sessionToken || process.env.AWS_SESSION_TOKEN;	
+	if(sessionToken) {
+		creds.sessionToken = sessionToken;
+	}
+	
 	const urlObject = urlParse(url);
 	const signable = {
 		method: opts.method,


### PR DESCRIPTION
Some services such as Lambda use temporarily generated [IAM STS credentials](http://docs.aws.amazon.com/STS/latest/UsingSTS/using-temp-creds.html) and therefore also need the `AWS_SESSION_TOKEN` variable to sign the request.
