### PR TITLE
Allow override of session tokens

### DIFF
--- a/main.js
+++ b/main.js
@@ -23,8 +23,8 @@ function signedFetch(url, opts, creds) {
 	creds.accessKeyId  = creds.accessKeyId || process.env.ES_AWS_ACCESS_KEY || process.env.AWS_ACCESS_KEY || process.env.AWS_ACCESS_KEY_ID;
 	creds.secretAccessKey  = creds.secretAccessKey || process.env.ES_AWS_SECRET_ACCESS_KEY || process.env.AWS_SECRET_ACCESS_KEY;
 
-	const sessionToken = creds.sessionToken || process.env.AWS_SESSION_TOKEN;	
-	if(sessionToken) {
+	const sessionToken = creds.sessionToken || process.env.ES_AWS_SESSION_TOKEN || process.env.AWS_SESSION_TOKEN;	
+	if (sessionToken) {
 		creds.sessionToken = sessionToken;
 	}
 	


### PR DESCRIPTION
We're having issues with Lambda's running under a role getting mixed up credentials.

If you define `ES_AWS_ACCESS_KEY_ID` under a role, the logic mixes up two sets of credentials that will get rejected.