### PR TITLE
Allow session token to be disabled by setting ES_AWS_SESSION_TOKEN to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ signedFetch(url, opts, { accessKeyId: ???, secretAccessKey: ??? });
 
 - Or, set `ES_AWS_ACCESS_KEY` and `ES_AWS_SECRET_ACCESS_KEY` environment variables, or
 - Set `AWS_ACCESS_KEY` and `AWS_SECRET_ACCESS_KEY` environment variables, or
-- Set the `ES_AWS_SESSION_TOKEN` or `AWS_SESSION_TOKEN` environment variables. If you don't want this to be automatically picked up (for example in a Lambda where the `AWS_SESSION_TOKEN` may reflect an assumed role), set `ES_AWS_SESSION_TOKEN` to disable this.
+- Set the `ES_AWS_SESSION_TOKEN` or `AWS_SESSION_TOKEN` environment variables. If you don't want this to be automatically picked up (for example in a Lambda where the `AWS_SESSION_TOKEN` may reflect an assumed role), set `ES_AWS_SESSION_TOKEN` to `false` to disable this.
 
 ```js
 const signedFetch = require('signed-aws-es-fetch');

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ signedFetch(url, opts, { accessKeyId: ???, secretAccessKey: ??? });
 ```
 
 - Or, set `ES_AWS_ACCESS_KEY` and `ES_AWS_SECRET_ACCESS_KEY` environment variables, or
-- Set `AWS_ACCESS_KEY` and `AWS_SECRET_ACCESS_KEY` environment variables.
+- Set `AWS_ACCESS_KEY` and `AWS_SECRET_ACCESS_KEY` environment variables, or
+- Set the `ES_AWS_SESSION_TOKEN` or `AWS_SESSION_TOKEN` environment variables. If you don't want this to be automatically picked up (for example in a Lambda where the `AWS_SESSION_TOKEN` may reflect an assumed role), set `ES_AWS_SESSION_TOKEN` to disable this.
 
 ```js
 const signedFetch = require('signed-aws-es-fetch');

--- a/main.js
+++ b/main.js
@@ -23,11 +23,14 @@ function signedFetch(url, opts, creds) {
 	creds.accessKeyId  = creds.accessKeyId || process.env.ES_AWS_ACCESS_KEY || process.env.AWS_ACCESS_KEY || process.env.AWS_ACCESS_KEY_ID;
 	creds.secretAccessKey  = creds.secretAccessKey || process.env.ES_AWS_SECRET_ACCESS_KEY || process.env.AWS_SECRET_ACCESS_KEY;
 
-	const sessionToken = creds.sessionToken || process.env.ES_AWS_SESSION_TOKEN || process.env.AWS_SESSION_TOKEN;	
+	let sessionToken = creds.sessionToken;
+	if (process.env.ES_AWS_SESSION_TOKEN !== false) {
+		sessionToken = sessionToken || process.env.ES_AWS_SESSION_TOKEN || process.env.AWS_SESSION_TOKEN;
+	}
 	if (sessionToken) {
 		creds.sessionToken = sessionToken;
 	}
-	
+
 	const urlObject = urlParse(url);
 	const signable = {
 		method: opts.method,


### PR DESCRIPTION
Attempt to address Issue #11 by allowing the use of `ES_AWS_SESSION_TOKEN=false` in environment variables to disable automatic use of `ES_AWS_SESSION_TOKEN` or `AWS_SESSION_TOKEN`.  Still leaves any token passed in via the creds object available in all cases.